### PR TITLE
Add dynamic form builder with preview and saved forms

### DIFF
--- a/upliance/src/App.js
+++ b/upliance/src/App.js
@@ -1,25 +1,60 @@
-import logo from './logo.svg';
+import React, { useState, useEffect } from 'react';
 import './App.css';
+import FormBuilder from './FormBuilder';
+import PreviewForm from './PreviewForm';
+import MyForms from './MyForms';
 
 function App() {
+  const [page, setPage] = useState('create');
+  const [currentForm, setCurrentForm] = useState({ name: '', fields: [] });
+  const [forms, setForms] = useState([]);
+
+  useEffect(() => {
+    const stored = localStorage.getItem('forms');
+    if (stored) setForms(JSON.parse(stored));
+  }, []);
+
+  const saveForm = (form) => {
+    const updated = [...forms, form];
+    setForms(updated);
+    localStorage.setItem('forms', JSON.stringify(updated));
+  };
+
+  const selectForm = (form) => {
+    setCurrentForm(form);
+    setPage('preview');
+  };
+
+  let content = null;
+  if (page === 'create') {
+    content = (
+      <FormBuilder
+        form={currentForm}
+        setForm={setCurrentForm}
+        onSave={(f) => {
+          saveForm(f);
+          setPage('preview');
+        }}
+        onPreview={() => setPage('preview')}
+      />
+    );
+  } else if (page === 'preview') {
+    content = <PreviewForm form={currentForm} onBack={() => setPage('create')} />;
+  } else if (page === 'myforms') {
+    content = <MyForms forms={forms} onSelect={selectForm} />;
+  }
+
   return (
     <div className="App">
-      <header className="App-header">
-        <img src={logo} className="App-logo" alt="logo" />
-        <p>
-          Edit <code>src/App.js</code> and save to reload.
-        </p>
-        <a
-          className="App-link"
-          href="https://reactjs.org"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          Learn React
-        </a>
-      </header>
+      <nav style={{ marginBottom: '20px' }}>
+        <button onClick={() => setPage('create')}>Create</button>
+        <button onClick={() => setPage('preview')}>Preview</button>
+        <button onClick={() => setPage('myforms')}>My Forms</button>
+      </nav>
+      {content}
     </div>
   );
 }
 
 export default App;
+

--- a/upliance/src/App.test.js
+++ b/upliance/src/App.test.js
@@ -1,8 +1,10 @@
 import { render, screen } from '@testing-library/react';
 import App from './App';
 
-test('renders learn react link', () => {
+test('renders navigation buttons', () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+  expect(screen.getAllByRole('button', { name: /Create/i }).length).toBeGreaterThan(0);
+  expect(screen.getAllByRole('button', { name: /Preview/i }).length).toBeGreaterThan(0);
+  expect(screen.getByRole('button', { name: /My Forms/i })).toBeInTheDocument();
 });
+

--- a/upliance/src/FormBuilder.js
+++ b/upliance/src/FormBuilder.js
@@ -1,0 +1,149 @@
+import React, { useState } from 'react';
+
+function FieldEditor({ field, index, fields, onChange, onRemove, onMove }) {
+  const handleChange = (e) => {
+    const { name, value, type, checked } = e.target;
+    onChange(index, { ...field, [name]: type === 'checkbox' ? checked : value });
+  };
+
+  return (
+    <div style={{ border: '1px solid #ccc', padding: '10px', marginBottom: '10px' }}>
+      <div>
+        <label>Type: </label>
+        <select name="type" value={field.type} onChange={handleChange}>
+          <option value="text">Text</option>
+          <option value="number">Number</option>
+          <option value="textarea">Textarea</option>
+          <option value="select">Select</option>
+          <option value="radio">Radio</option>
+          <option value="checkbox">Checkbox</option>
+          <option value="date">Date</option>
+        </select>
+      </div>
+      <div>
+        <label>Label: </label>
+        <input name="label" value={field.label} onChange={handleChange} />
+      </div>
+      <div>
+        <label>Required: </label>
+        <input type="checkbox" name="required" checked={field.required} onChange={handleChange} />
+      </div>
+      <div>
+        <label>Default: </label>
+        <input name="defaultValue" value={field.defaultValue} onChange={handleChange} />
+      </div>
+      {(field.type === 'select' || field.type === 'radio' || field.type === 'checkbox') && (
+        <div>
+          <label>Options (comma separated): </label>
+          <input name="options" value={field.options || ''} onChange={handleChange} />
+        </div>
+      )}
+      <div>
+        <label>Min Length: </label>
+        <input name="minLength" value={field.minLength || ''} onChange={handleChange} />
+      </div>
+      <div>
+        <label>Max Length: </label>
+        <input name="maxLength" value={field.maxLength || ''} onChange={handleChange} />
+      </div>
+      <div>
+        <label>Email: </label>
+        <input type="checkbox" name="email" checked={field.email || false} onChange={handleChange} />
+      </div>
+      <div>
+        <label>Password Rule: </label>
+        <input type="checkbox" name="password" checked={field.password || false} onChange={handleChange} />
+      </div>
+      <div>
+        <label>Derived: </label>
+        <input type="checkbox" name="derived" checked={field.derived || false} onChange={handleChange} />
+      </div>
+      {field.derived && (
+        <>
+          <div>
+            <label>Parent IDs (comma separated): </label>
+            <input name="parents" value={field.parents || ''} onChange={handleChange} />
+          </div>
+          <div>
+            <label>Formula (use values.parentId): </label>
+            <input name="formula" value={field.formula || ''} onChange={handleChange} />
+          </div>
+        </>
+      )}
+      <div>
+        <button type="button" onClick={() => onMove(index, -1)}>Up</button>
+        <button type="button" onClick={() => onMove(index, 1)}>Down</button>
+        <button type="button" onClick={() => onRemove(index)}>Delete</button>
+      </div>
+    </div>
+  );
+}
+
+export default function FormBuilder({ form, setForm, onSave, onPreview }) {
+  const [fields, setFields] = useState(form.fields || []);
+
+  const addField = () => {
+    setFields([
+      ...fields,
+      {
+        id: Date.now().toString(),
+        type: 'text',
+        label: '',
+        required: false,
+        defaultValue: '',
+      },
+    ]);
+  };
+
+  const updateField = (index, newField) => {
+    const updated = fields.slice();
+    updated[index] = newField;
+    setFields(updated);
+  };
+
+  const removeField = (index) => {
+    const updated = fields.slice();
+    updated.splice(index, 1);
+    setFields(updated);
+  };
+
+  const moveField = (index, dir) => {
+    const newIndex = index + dir;
+    if (newIndex < 0 || newIndex >= fields.length) return;
+    const updated = fields.slice();
+    const [moved] = updated.splice(index, 1);
+    updated.splice(newIndex, 0, moved);
+    setFields(updated);
+  };
+
+  const save = () => {
+    const name = window.prompt('Form name');
+    if (!name) return;
+    const newForm = { ...form, name, created: new Date().toISOString(), fields };
+    setForm(newForm);
+    onSave(newForm);
+  };
+
+  return (
+    <div>
+      <h2>Create Form</h2>
+      {fields.map((field, idx) => (
+        <FieldEditor
+          key={field.id}
+          field={field}
+          index={idx}
+          fields={fields}
+          onChange={updateField}
+          onRemove={removeField}
+          onMove={moveField}
+        />
+      ))}
+      <button type="button" onClick={addField}>Add Field</button>
+      <div style={{ marginTop: '20px' }}>
+        <button type="button" onClick={save}>Save Form</button>
+        <button type="button" onClick={onPreview}>Preview</button>
+      </div>
+    </div>
+  );
+}
+

--- a/upliance/src/MyForms.js
+++ b/upliance/src/MyForms.js
@@ -1,0 +1,20 @@
+import React from 'react';
+
+export default function MyForms({ forms, onSelect }) {
+  return (
+    <div>
+      <h2>My Forms</h2>
+      <ul>
+        {forms.map((f) => (
+          <li key={f.name} style={{ marginBottom: '5px' }}>
+            <button type="button" onClick={() => onSelect(f)}>
+              {f.name} - {new Date(f.created).toLocaleString()}
+            </button>
+          </li>
+        ))}
+      </ul>
+      {forms.length === 0 && <div>No forms saved.</div>}
+    </div>
+  );
+}
+

--- a/upliance/src/PreviewForm.js
+++ b/upliance/src/PreviewForm.js
@@ -1,0 +1,140 @@
+import React, { useState, useEffect } from 'react';
+
+function evaluateFormula(formula, values) {
+  try {
+    // eslint-disable-next-line no-new-func
+    const fn = new Function('values', `return ${formula}`);
+    return fn(values);
+  } catch (e) {
+    return '';
+  }
+}
+
+export default function PreviewForm({ form, onBack }) {
+  const [values, setValues] = useState({});
+  const [errors, setErrors] = useState({});
+
+  useEffect(() => {
+    const initial = {};
+    form.fields.forEach(f => {
+      initial[f.id] = f.defaultValue || '';
+    });
+    setValues(initial);
+  }, [form]);
+
+  const handleChange = (id, value) => {
+    const newValues = { ...values, [id]: value };
+    // handle derived fields
+    form.fields.forEach(f => {
+      if (f.derived && f.formula) {
+        newValues[f.id] = evaluateFormula(f.formula, newValues);
+      }
+    });
+    setValues(newValues);
+  };
+
+  const validate = () => {
+    const newErrors = {};
+    form.fields.forEach(f => {
+      const val = values[f.id];
+      if (f.required && !val) newErrors[f.id] = 'Required';
+      if (f.minLength && val.length < parseInt(f.minLength)) newErrors[f.id] = `Min ${f.minLength}`;
+      if (f.maxLength && val.length > parseInt(f.maxLength)) newErrors[f.id] = `Max ${f.maxLength}`;
+      if (f.email && val && !/^[^@\s]+@[^@\s]+\.[^@\s]+$/.test(val)) newErrors[f.id] = 'Invalid email';
+      if (f.password && val && (!/[0-9]/.test(val) || val.length < 8)) newErrors[f.id] = 'Weak password';
+    });
+    setErrors(newErrors);
+    return Object.keys(newErrors).length === 0;
+  };
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    if (validate()) {
+      alert('Form valid!');
+    }
+  };
+
+  const renderField = (field) => {
+    const common = {
+      id: field.id,
+      value: values[field.id] || '',
+      onChange: (e) => handleChange(field.id, e.target.type === 'checkbox' ? e.target.checked : e.target.value),
+    };
+
+    switch (field.type) {
+      case 'textarea':
+        return <textarea {...common} />;
+      case 'number':
+        return <input type="number" {...common} />;
+      case 'select':
+        return (
+          <select {...common}>
+            <option value="" />
+            {(field.options || '').split(',').map(opt => (
+              <option key={opt} value={opt.trim()}>{opt.trim()}</option>
+            ))}
+          </select>
+        );
+      case 'radio':
+        return (
+          <div>
+            {(field.options || '').split(',').map(opt => (
+              <label key={opt}>
+                <input
+                  type="radio"
+                  name={field.id}
+                  value={opt.trim()}
+                  checked={values[field.id] === opt.trim()}
+                  onChange={(e) => handleChange(field.id, e.target.value)}
+                />
+                {opt.trim()}
+              </label>
+            ))}
+          </div>
+        );
+      case 'checkbox':
+        return (
+          <div>
+            {(field.options || '').split(',').map(opt => (
+              <label key={opt}>
+                <input
+                  type="checkbox"
+                  checked={(values[field.id] || {})[opt.trim()] || false}
+                  onChange={(e) => {
+                    const current = values[field.id] || {};
+                    current[opt.trim()] = e.target.checked;
+                    handleChange(field.id, { ...current });
+                  }}
+                />
+                {opt.trim()}
+              </label>
+            ))}
+          </div>
+        );
+      case 'date':
+        return <input type="date" {...common} />;
+      default:
+        return <input type="text" {...common} />;
+    }
+  };
+
+  return (
+    <div>
+      <h2>Preview: {form.name}</h2>
+      <form onSubmit={handleSubmit}>
+        {form.fields.map(f => (
+          <div key={f.id} style={{ marginBottom: '10px' }}>
+            <label>
+              {f.label} {f.required && '*'}
+              {renderField(f)}
+            </label>
+            {errors[f.id] && <div style={{ color: 'red' }}>{errors[f.id]}</div>}
+          </div>
+        ))}
+        <button type="submit">Submit</button>
+        <button type="button" onClick={onBack} style={{ marginLeft: '10px' }}>Back</button>
+      </form>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- implement form builder to configure fields, derived values, and save schemas to localStorage
- add preview renderer with validation rules and derived field updates
- list and open previously saved forms

## Testing
- `CI=true npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_6898969681e083249b1344720c61be03