### PR TITLE
Add CSS for form styling

### DIFF
--- a/upliance/src/FormBuilder.js
+++ b/upliance/src/FormBuilder.js
@@ -7,7 +7,7 @@ function FieldEditor({ field, index, fields, onChange, onRemove, onMove }) {
   };
 
   return (
-    <div style={{ border: '1px solid #ccc', padding: '10px', marginBottom: '10px' }}>
+    <div className="field-editor">
       <div>
         <label>Type: </label>
         <select name="type" value={field.type} onChange={handleChange}>
@@ -139,7 +139,7 @@ export default function FormBuilder({ form, setForm, onSave, onPreview }) {
         />
       ))}
       <button type="button" onClick={addField}>Add Field</button>
-      <div style={{ marginTop: '20px' }}>
+      <div className="form-actions">
         <button type="button" onClick={save}>Save Form</button>
         <button type="button" onClick={onPreview}>Preview</button>
       </div>

--- a/upliance/src/MyForms.js
+++ b/upliance/src/MyForms.js
@@ -6,7 +6,7 @@ export default function MyForms({ forms, onSelect }) {
       <h2>My Forms</h2>
       <ul>
         {forms.map((f) => (
-          <li key={f.name} style={{ marginBottom: '5px' }}>
+          <li key={f.name} className="form-list-item">
             <button type="button" onClick={() => onSelect(f)}>
               {f.name} - {new Date(f.created).toLocaleString()}
             </button>

--- a/upliance/src/PreviewForm.js
+++ b/upliance/src/PreviewForm.js
@@ -123,16 +123,16 @@ export default function PreviewForm({ form, onBack }) {
       <h2>Preview: {form.name}</h2>
       <form onSubmit={handleSubmit}>
         {form.fields.map(f => (
-          <div key={f.id} style={{ marginBottom: '10px' }}>
+          <div key={f.id} className="preview-field">
             <label>
               {f.label} {f.required && '*'}
               {renderField(f)}
             </label>
-            {errors[f.id] && <div style={{ color: 'red' }}>{errors[f.id]}</div>}
+            {errors[f.id] && <div className="error-text">{errors[f.id]}</div>}
           </div>
         ))}
         <button type="submit">Submit</button>
-        <button type="button" onClick={onBack} style={{ marginLeft: '10px' }}>Back</button>
+        <button type="button" onClick={onBack} className="back-button">Back</button>
       </form>
     </div>
   );

--- a/upliance/src/index.js
+++ b/upliance/src/index.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
+import './styles.css';
 import App from './App';
 import reportWebVitals from './reportWebVitals';
 

--- a/upliance/src/styles.css
+++ b/upliance/src/styles.css
@@ -1,0 +1,25 @@
+.field-editor {
+  border: 1px solid #ccc;
+  padding: 10px;
+  margin-bottom: 10px;
+}
+
+.form-actions {
+  margin-top: 20px;
+}
+
+.preview-field {
+  margin-bottom: 10px;
+}
+
+.error-text {
+  color: red;
+}
+
+.form-list-item {
+  margin-bottom: 5px;
+}
+
+.back-button {
+  margin-left: 10px;
+}


### PR DESCRIPTION
## Summary
- centralize common form spacing and colors in a new global stylesheet
- replace inline styles with CSS classes across form components
- load global styles in the app entry point

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_6898bd2dedc08324a3cf498e59323d7f