### PR TITLE
Ensure MyForms list uses unique keys

### DIFF
--- a/upliance/src/MyForms.js
+++ b/upliance/src/MyForms.js
@@ -6,7 +6,7 @@ export default function MyForms({ forms, onSelect }) {
       <h2>My Forms</h2>
       <ul>
         {forms.map((f) => (
-          <li key={f.name} className="form-list-item">
+          <li key={f.created} className="form-list-item">
             <button type="button" onClick={() => onSelect(f)}>
               {f.name} - {new Date(f.created).toLocaleString()}
             </button>


### PR DESCRIPTION
## Summary
- use form creation timestamp as list key to guarantee uniqueness and prevent React warnings

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_6898bf961a7083249815968841feda2f