### PR TITLE
Improve FormBuilder layout

### DIFF
--- a/upliance/src/FormBuilder.js
+++ b/upliance/src/FormBuilder.js
@@ -70,7 +70,7 @@ function FieldEditor({ field, index, fields, onChange, onRemove, onMove }) {
           </div>
         </>
       )}
-      <div>
+      <div className="field-editor-buttons">
         <button type="button" onClick={() => onMove(index, -1)}>Up</button>
         <button type="button" onClick={() => onMove(index, 1)}>Down</button>
         <button type="button" onClick={() => onRemove(index)}>Delete</button>
@@ -125,7 +125,7 @@ export default function FormBuilder({ form, setForm, onSave, onPreview }) {
   };
 
   return (
-    <div>
+    <div className="form-builder">
       <h2>Create Form</h2>
       {fields.map((field, idx) => (
         <FieldEditor

--- a/upliance/src/styles.css
+++ b/upliance/src/styles.css
@@ -12,6 +12,12 @@
   padding: 20px;
 }
 
+.form-builder {
+  max-width: 600px;
+  margin: 0 auto;
+  text-align: left;
+}
+
 .field-editor {
   background: #ffffff;
   border-radius: 8px;
@@ -21,10 +27,17 @@
   animation: fadeIn 0.5s ease;
 }
 
+.field-editor-buttons {
+  display: flex;
+  gap: 8px;
+  margin-top: 10px;
+}
+
 .form-actions {
   display: flex;
   gap: 10px;
   margin-top: 20px;
+  justify-content: center;
 }
 
 .preview-field {


### PR DESCRIPTION
## Summary
- add dedicated spacing for Up/Down/Delete controls
- center Save Form and Preview buttons
- constrain create-form width for better layout

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_6898d31ec4dc8324b32f3462b0649926