### PR TITLE
Fix form preview to include unsaved field edits

### DIFF
--- a/upliance/src/FormBuilder.js
+++ b/upliance/src/FormBuilder.js
@@ -124,6 +124,11 @@ export default function FormBuilder({ form, setForm, onSave, onPreview }) {
     onSave(newForm);
   };
 
+  const preview = () => {
+    setForm({ ...form, fields });
+    onPreview();
+  };
+
   return (
     <div className="form-builder">
       <h2>Create Form</h2>
@@ -141,7 +146,7 @@ export default function FormBuilder({ form, setForm, onSave, onPreview }) {
       <button type="button" onClick={addField}>Add Field</button>
       <div className="form-actions">
         <button type="button" onClick={save}>Save Form</button>
-        <button type="button" onClick={onPreview}>Preview</button>
+        <button type="button" onClick={preview}>Preview</button>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- update FormBuilder preview handler to sync current fields before navigating

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_6898d8c49e208324821ea55516fda9fe