### PR TITLE
feat: make derived fields read-only in preview

### DIFF
--- a/upliance/package.json
+++ b/upliance/package.json
@@ -38,6 +38,11 @@
   },
   "devDependencies": {
     "autoprefixer": "^10.4.21",
-    "postcss": "^8.5.6"
+    "postcss": "^8.5.6",
+    "@types/jest": "^29.5.12",
+    "@types/node": "^20.11.30",
+    "@types/react": "^18.2.50",
+    "@types/react-dom": "^18.2.19",
+    "typescript": "^5.4.5"
   }
 }

--- a/upliance/src/PreviewForm.test.tsx
+++ b/upliance/src/PreviewForm.test.tsx
@@ -1,0 +1,30 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import PreviewForm from './PreviewForm';
+
+describe('PreviewForm derived fields', () => {
+  const form = {
+    name: 'Calc',
+    fields: [
+      { id: 'a', type: 'number', label: 'A', defaultValue: '2' },
+      { id: 'b', type: 'number', label: 'B', defaultValue: '3' },
+      {
+        id: 'sum',
+        type: 'number',
+        label: 'Sum',
+        derived: true,
+        formula: 'Number(values.a) + Number(values.b)'
+      }
+    ]
+  };
+
+  it('calculates derived field and keeps it read-only', () => {
+    render(<PreviewForm form={form} onBack={() => {}} />);
+    const aInput = screen.getByLabelText('A');
+    const sumInput = screen.getByLabelText('Sum') as HTMLInputElement;
+
+    expect(sumInput.value).toBe('5');
+    fireEvent.change(aInput, { target: { value: '4' } });
+    expect(sumInput.value).toBe('7');
+    expect(sumInput).toHaveAttribute('readOnly');
+  });
+});

--- a/upliance/src/PreviewForm.tsx
+++ b/upliance/src/PreviewForm.tsx
@@ -1,6 +1,32 @@
 import React, { useState, useEffect } from 'react';
 
-function evaluateFormula(formula, values) {
+interface Field {
+  id: string;
+  type: string;
+  label: string;
+  required?: boolean;
+  defaultValue?: any;
+  options?: string;
+  minLength?: string;
+  maxLength?: string;
+  email?: boolean;
+  password?: boolean;
+  derived?: boolean;
+  parents?: string;
+  formula?: string;
+}
+
+interface Form {
+  name: string;
+  fields: Field[];
+}
+
+interface PreviewFormProps {
+  form: Form;
+  onBack: () => void;
+}
+
+function evaluateFormula(formula: string, values: Record<string, any>): any {
   try {
     // eslint-disable-next-line no-new-func
     const fn = new Function('values', `return ${formula}`);
@@ -10,21 +36,26 @@ function evaluateFormula(formula, values) {
   }
 }
 
-export default function PreviewForm({ form, onBack }) {
-  const [values, setValues] = useState({});
-  const [errors, setErrors] = useState({});
+export default function PreviewForm({ form, onBack }: PreviewFormProps) {
+  const [values, setValues] = useState<Record<string, any>>({});
+  const [errors, setErrors] = useState<Record<string, string>>({});
 
   useEffect(() => {
-    const initial = {};
+    const initial: Record<string, any> = {};
     form.fields.forEach(f => {
       initial[f.id] = f.defaultValue || '';
+    });
+    // compute derived fields on mount
+    form.fields.forEach(f => {
+      if (f.derived && f.formula) {
+        initial[f.id] = evaluateFormula(f.formula, initial);
+      }
     });
     setValues(initial);
   }, [form]);
 
-  const handleChange = (id, value) => {
-    const newValues = { ...values, [id]: value };
-    // handle derived fields
+  const handleChange = (id: string, value: any) => {
+    const newValues: Record<string, any> = { ...values, [id]: value };
     form.fields.forEach(f => {
       if (f.derived && f.formula) {
         newValues[f.id] = evaluateFormula(f.formula, newValues);
@@ -33,8 +64,8 @@ export default function PreviewForm({ form, onBack }) {
     setValues(newValues);
   };
 
-  const validate = () => {
-    const newErrors = {};
+  const validate = (): boolean => {
+    const newErrors: Record<string, string> = {};
     form.fields.forEach(f => {
       const val = values[f.id];
       if (f.required && !val) newErrors[f.id] = 'Required';
@@ -47,18 +78,22 @@ export default function PreviewForm({ form, onBack }) {
     return Object.keys(newErrors).length === 0;
   };
 
-  const handleSubmit = (e) => {
+  const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     if (validate()) {
       alert('Form valid!');
     }
   };
 
-  const renderField = (field) => {
+  const renderField = (field: Field) => {
+    const isDerived = field.derived;
     const common = {
       id: field.id,
       value: values[field.id] || '',
-      onChange: (e) => handleChange(field.id, e.target.type === 'checkbox' ? e.target.checked : e.target.value),
+      onChange: (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>) =>
+        handleChange(field.id, e.target.type === 'checkbox' ? (e.target as HTMLInputElement).checked : e.target.value),
+      readOnly: isDerived && !['select', 'radio', 'checkbox'].includes(field.type),
+      disabled: isDerived && ['select', 'radio', 'checkbox'].includes(field.type),
     };
 
     switch (field.type) {
@@ -86,6 +121,7 @@ export default function PreviewForm({ form, onBack }) {
                   value={opt.trim()}
                   checked={values[field.id] === opt.trim()}
                   onChange={(e) => handleChange(field.id, e.target.value)}
+                  disabled={isDerived}
                 />
                 {opt.trim()}
               </label>
@@ -102,9 +138,10 @@ export default function PreviewForm({ form, onBack }) {
                   checked={(values[field.id] || {})[opt.trim()] || false}
                   onChange={(e) => {
                     const current = values[field.id] || {};
-                    current[opt.trim()] = e.target.checked;
+                    current[opt.trim()] = (e.target as HTMLInputElement).checked;
                     handleChange(field.id, { ...current });
                   }}
+                  disabled={isDerived}
                 />
                 {opt.trim()}
               </label>

--- a/upliance/tsconfig.json
+++ b/upliance/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary
- compute derived field values on mount and prevent editing in preview
- add TypeScript setup and convert PreviewForm to use strong typing
- test derived field updates and read-only behavior

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_6898dc08ea288324b8f1512a8498017e