### PR TITLE
Fix input overflow in form builder

### DIFF
--- a/upliance/src/styles.css
+++ b/upliance/src/styles.css
@@ -55,6 +55,7 @@ select {
   border: 1px solid #ccc;
   border-radius: 4px;
   transition: border-color 0.3s;
+  box-sizing: border-box;
 }
 
 input:focus,


### PR DESCRIPTION
## Summary
- prevent text inputs from overflowing their containers by including padding in width calculation

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_689b1c4410c8832cbb8b9cd7d49082d5