### PR TITLE
Handle checkbox required validation

### DIFF
--- a/upliance/src/PreviewForm.test.tsx
+++ b/upliance/src/PreviewForm.test.tsx
@@ -1,6 +1,11 @@
 import { render, screen, fireEvent } from '@testing-library/react';
 import PreviewForm from './PreviewForm';
 
+beforeAll(() => {
+  // prevent jsdom error for alert
+  window.alert = jest.fn();
+});
+
 describe('PreviewForm derived fields', () => {
   const form = {
     name: 'Calc',
@@ -26,5 +31,22 @@ describe('PreviewForm derived fields', () => {
     fireEvent.change(aInput, { target: { value: '4' } });
     expect(sumInput.value).toBe('7');
     expect(sumInput).toHaveAttribute('readOnly');
+  });
+});
+
+describe('PreviewForm validation', () => {
+  it('requires at least one checkbox when marked required', () => {
+    const form = {
+      name: 'Terms',
+      fields: [
+        { id: 'terms', type: 'checkbox', label: 'Terms', required: true, options: 'Yes,No' }
+      ]
+    };
+    render(<PreviewForm form={form} onBack={() => {}} />);
+    fireEvent.click(screen.getByText('Submit'));
+    expect(screen.getByText('Required')).toBeInTheDocument();
+    fireEvent.click(screen.getByLabelText('Yes'));
+    fireEvent.click(screen.getByText('Submit'));
+    expect(screen.queryByText('Required')).toBeNull();
   });
 });

--- a/upliance/src/PreviewForm.tsx
+++ b/upliance/src/PreviewForm.tsx
@@ -66,13 +66,29 @@ export default function PreviewForm({ form, onBack }: PreviewFormProps) {
 
   const validate = (): boolean => {
     const newErrors: Record<string, string> = {};
+
+    const isEmpty = (field: Field, val: any): boolean => {
+      if (field.type === 'checkbox') {
+        return !val || Object.values(val).every(v => !v);
+      }
+      return val === undefined || val === null || val === '';
+    };
+
+    const getLength = (field: Field, val: any): number => {
+      if (field.type === 'checkbox' && val) {
+        return Object.values(val).filter(Boolean).length;
+      }
+      return typeof val === 'string' ? val.length : 0;
+    };
+
     form.fields.forEach(f => {
       const val = values[f.id];
-      if (f.required && !val) newErrors[f.id] = 'Required';
-      if (f.minLength && val.length < parseInt(f.minLength)) newErrors[f.id] = `Min ${f.minLength}`;
-      if (f.maxLength && val.length > parseInt(f.maxLength)) newErrors[f.id] = `Max ${f.maxLength}`;
-      if (f.email && val && !/^[^@\s]+@[^@\s]+\.[^@\s]+$/.test(val)) newErrors[f.id] = 'Invalid email';
-      if (f.password && val && (!/[0-9]/.test(val) || val.length < 8)) newErrors[f.id] = 'Weak password';
+      if (f.required && isEmpty(f, val)) newErrors[f.id] = 'Required';
+      const len = getLength(f, val);
+      if (f.minLength && len < parseInt(f.minLength)) newErrors[f.id] = `Min ${f.minLength}`;
+      if (f.maxLength && len > parseInt(f.maxLength)) newErrors[f.id] = `Max ${f.maxLength}`;
+      if (f.email && typeof val === 'string' && val && !/^[^@\s]+@[^@\s]+\.[^@\s]+$/.test(val)) newErrors[f.id] = 'Invalid email';
+      if (f.password && typeof val === 'string' && val && (!/[0-9]/.test(val) || val.length < 8)) newErrors[f.id] = 'Weak password';
     });
     setErrors(newErrors);
     return Object.keys(newErrors).length === 0;


### PR DESCRIPTION
## Summary
- improve validation to correctly detect empty checkbox fields and compute field lengths
- add unit test to cover required checkbox validation and mock browser alert

## Testing
- `CI=true npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_689b1d3bbe00832cb936a60e5999e4a5